### PR TITLE
fix: size of .footerCopyright p

### DIFF
--- a/src/components/common/Footer/Footer.module.scss
+++ b/src/components/common/Footer/Footer.module.scss
@@ -117,6 +117,9 @@
   color: $white-text;
   text-align: center;
 }
+.footerCopyright p {
+  @include text-accent;
+}
 ///// media /////////
 @media (min-width: $large-desktop) {
   .footer {
@@ -128,6 +131,10 @@
   .footer {
     padding: 50px 40px;
     font-size: 1rem;
+    font-weight: 500;
+  }
+  .footerCopyright p {
+    font-size: 0.875rem;
     font-weight: 500;
   }
 }
@@ -147,6 +154,10 @@
     display: flex;
     justify-content: center;
     margin-top: 2rem;
+  }
+  .footerCopyright p {
+    font-size: 0.875rem;
+    font-weight: 500;
   }
 }
 
@@ -178,8 +189,8 @@
     left: 4.8rem;
   }
   ////
-  .footerCopyright {
-    font-size: 14px;
+  .footerCopyright p {
+    font-size: 0.875rem;
     font-weight: 500;
   }
 }


### PR DESCRIPTION
In my previous branch, everything was okay with the size of this paragraph. 
How I found out the wrong size was pulled from the file, possibly after normalizing the code
![image](https://github.com/user-attachments/assets/9d7e9d27-9cae-435d-b1fe-10ba38cc1431)

That's why I set the desired text size directly to the element 